### PR TITLE
feat(eslint-config)!: change return-await rule to always enforce usage

### DIFF
--- a/packages/eslint-config/src/configs/ts-base.mts
+++ b/packages/eslint-config/src/configs/ts-base.mts
@@ -119,7 +119,7 @@ const typescriptEslintRules = defineConfig({
     '@typescript-eslint/no-dupe-class-members': 'error',
     '@typescript-eslint/no-unused-expressions': 'error',
     '@typescript-eslint/no-unused-vars': ['warn', { ignoreRestSiblings: true }],
-    '@typescript-eslint/return-await': 'error',
+    '@typescript-eslint/return-await': ['error','always'],
     '@typescript-eslint/consistent-type-imports': 'error',
   },
 });


### PR DESCRIPTION
Changes:
Updates the central ESLint configuration file to enforce "@typescript-eslint/return-await": "always".

Why:
Zero-cost async stack traces: We get full, accurate stack traces when a returned promise rejects.

Prevents try/catch bugs: Eliminates the trap where a developer wraps a return promise in a try/catch, but the catch fails to fire because the promise wasn't awaited.

No performance penalty: Modern V8 natively handles return await without the historical microtask overhead.

⚠️ BREAKING CHANGE ⚠️
Consuming projects will see linting errors for any un-awaited promises returned from async functions. These can be safely auto-resolved by running eslint --fix on the consuming codebase.